### PR TITLE
Adding signer address in result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { FeeSplitCalculator } from './calculators/feeSplit.calculator';
 import { RpcService } from './utils/rateLimit';
 import { logger } from './utils/logger';
 import { writeDetailedReport, writeTransferFile } from './utils/outputWriter';
+import { StakingApiService } from './services/stakingApi.service';
 
 /**
  * Main application class
@@ -204,10 +205,15 @@ class FeeSplitApp {
       );
       logger.info(`Fee Splits: ${JSON.stringify(scoresObj, null, 2)}`);
 
-      // Step 8: Write output files
-      logger.info('\n--- Step 8: Writing output files ---');
-      const detailedReportPath = writeDetailedReport(result, config.outputPath);
-      const transferFilePath = writeTransferFile(result, config.outputPath);
+      // Step 8: Fetch validator signer addresses from Polygon Staking API
+      logger.info('\n--- Step 8: Fetching validator signer addresses ---');
+      const stakingApiService = new StakingApiService();
+      const signerMap = await stakingApiService.getValidatorSigners();
+
+      // Step 9: Write output files
+      logger.info('\n--- Step 9: Writing output files ---');
+      const detailedReportPath = writeDetailedReport(result, config.outputPath, signerMap);
+      const transferFilePath = writeTransferFile(result, config.outputPath, signerMap);
 
       logger.info('\n=== Processing completed successfully ===');
       logger.info(`Detailed report: ${detailedReportPath}`);

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -149,6 +149,7 @@ export interface TransferData {
   };
   allocations: Array<{
     validatorId: number;
+    signer: string; // Signer wallet address from Polygon Staking API
     amount: string; // POL amount as decimal string
   }>;
 }

--- a/src/services/stakingApi.service.ts
+++ b/src/services/stakingApi.service.ts
@@ -3,9 +3,13 @@
  */
 
 import axios from 'axios';
+import pRetry from 'p-retry';
 import { logger } from '../utils/logger';
 
 const STAKING_API_BASE = 'https://staking-api.polygon.technology/api/v2';
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const MAX_PAGES = 20;
 
 interface ValidatorApiResponse {
   id: number;
@@ -27,20 +31,50 @@ export class StakingApiService {
   /**
    * Fetch all validators from the staking API and return a map of validatorId -> signer address.
    * Handles pagination automatically.
+   * Returns an empty map on failure so that the pipeline can still produce output.
    */
   async getValidatorSigners(): Promise<Map<number, string>> {
+    try {
+      return await this.fetchAllValidators();
+    } catch (error) {
+      logger.warn(
+        'StakingApi: Failed to fetch validator signer addresses after retries. ' +
+        'Output files will use "unknown" for signer fields.',
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return new Map();
+    }
+  }
+
+  private async fetchAllValidators(): Promise<Map<number, string>> {
     const signerMap = new Map<number, string>();
     const limit = 100;
     let offset = 0;
     let total = Infinity;
+    let pages = 0;
 
     logger.info('StakingApi: Fetching validator signer addresses');
 
-    while (offset < total) {
+    while (offset < total && pages < MAX_PAGES) {
       const url = `${STAKING_API_BASE}/validators?limit=${limit}&offset=${offset}`;
-      const response = await axios.get<PaginatedResponse>(url);
-      const { summary, result } = response.data;
 
+      const response = await pRetry(
+        () => axios.get<PaginatedResponse>(url, { timeout: REQUEST_TIMEOUT_MS }),
+        {
+          retries: MAX_RETRIES,
+          minTimeout: 1_000,
+          factor: 2,
+          onFailedAttempt: (err) => {
+            logger.warn(
+              `StakingApi: Request failed (attempt ${err.attemptNumber}/${MAX_RETRIES + 1}), ` +
+              `${err.retriesLeft} retries left`,
+              { error: err.message },
+            );
+          },
+        },
+      );
+
+      const { summary, result } = response.data;
       total = summary.total;
 
       for (const validator of result) {
@@ -49,9 +83,14 @@ export class StakingApiService {
 
       logger.info(`StakingApi: Fetched ${offset + result.length} / ${total} validators`);
       offset += result.length;
+      pages++;
 
       // Safety: if the API returns an empty page before reaching total, stop
       if (result.length === 0) break;
+    }
+
+    if (pages >= MAX_PAGES) {
+      logger.warn(`StakingApi: Reached max page limit (${MAX_PAGES}), some validators may be missing`);
     }
 
     logger.info(`StakingApi: Loaded signer addresses for ${signerMap.size} validators`);

--- a/src/services/stakingApi.service.ts
+++ b/src/services/stakingApi.service.ts
@@ -1,0 +1,60 @@
+/**
+ * Staking API service for fetching validator metadata from the Polygon Staking API
+ */
+
+import axios from 'axios';
+import { logger } from '../utils/logger';
+
+const STAKING_API_BASE = 'https://staking-api.polygon.technology/api/v2';
+
+interface ValidatorApiResponse {
+  id: number;
+  signer: string;
+}
+
+interface PaginatedResponse {
+  success: boolean;
+  summary: {
+    limit: number;
+    offset: number;
+    total: number;
+    size: number;
+  };
+  result: ValidatorApiResponse[];
+}
+
+export class StakingApiService {
+  /**
+   * Fetch all validators from the staking API and return a map of validatorId -> signer address.
+   * Handles pagination automatically.
+   */
+  async getValidatorSigners(): Promise<Map<number, string>> {
+    const signerMap = new Map<number, string>();
+    const limit = 100;
+    let offset = 0;
+    let total = Infinity;
+
+    logger.info('StakingApi: Fetching validator signer addresses');
+
+    while (offset < total) {
+      const url = `${STAKING_API_BASE}/validators?limit=${limit}&offset=${offset}`;
+      const response = await axios.get<PaginatedResponse>(url);
+      const { summary, result } = response.data;
+
+      total = summary.total;
+
+      for (const validator of result) {
+        signerMap.set(validator.id, validator.signer);
+      }
+
+      logger.info(`StakingApi: Fetched ${offset + result.length} / ${total} validators`);
+      offset += result.length;
+
+      // Safety: if the API returns an empty page before reaching total, stop
+      if (result.length === 0) break;
+    }
+
+    logger.info(`StakingApi: Loaded signer addresses for ${signerMap.size} validators`);
+    return signerMap;
+  }
+}

--- a/src/utils/outputWriter.ts
+++ b/src/utils/outputWriter.ts
@@ -13,11 +13,13 @@ import { logger } from './logger';
  *
  * @param result - Complete calculation result with interval details
  * @param outputDir - Directory to write the file to
+ * @param signerMap - Map of validatorId -> signer address from Polygon Staking API
  * @returns Path to the generated file
  */
 export function writeDetailedReport(
   result: CalculationResult,
-  outputDir: string
+  outputDir: string,
+  signerMap: Map<number, string>
 ): string {
   // Ensure output directory exists
   if (!fs.existsSync(outputDir)) {
@@ -29,11 +31,25 @@ export function writeDetailedReport(
   const filename = `fee-splits-detailed-${result.metadata.startPolygonBlock}-${result.metadata.endPolygonBlock}-${timestamp}.json`;
   const filePath = path.join(outputDir, filename);
 
+  // Enrich each interval's validator entries with signer addresses
+  const enrichedIntervals = result.intervals.map(interval => ({
+    ...interval,
+    validators: Object.fromEntries(
+      Object.entries(interval.validators).map(([validatorId, data]) => [
+        validatorId,
+        {
+          signer: signerMap.get(Number(validatorId)) ?? 'unknown',
+          ...data,
+        },
+      ])
+    ),
+  }));
+
   // Build the output structure
   const output = {
     metadata: result.metadata,
     summary: result.summary,
-    intervals: result.intervals,
+    intervals: enrichedIntervals,
   };
 
   // Write to file with pretty formatting
@@ -48,11 +64,13 @@ export function writeDetailedReport(
  *
  * @param result - Complete calculation result
  * @param outputDir - Directory to write the file to
+ * @param signerMap - Map of validatorId -> signer address from Polygon Staking API
  * @returns Path to the generated file
  */
 export function writeTransferFile(
   result: CalculationResult,
-  outputDir: string
+  outputDir: string,
+  signerMap: Map<number, string>
 ): string {
   // Ensure output directory exists
   if (!fs.existsSync(outputDir)) {
@@ -64,10 +82,11 @@ export function writeTransferFile(
   const filename = `fee-splits-${result.metadata.startPolygonBlock}-${result.metadata.endPolygonBlock}-${timestamp}.json`;
   const filePath = path.join(outputDir, filename);
 
-  // Convert final allocations map to sorted array
+  // Convert final allocations map to sorted array, enriched with signer address
   const allocations = Array.from(result.finalAllocations.entries())
     .map(([validatorId, amount]) => ({
       validatorId,
+      signer: signerMap.get(validatorId) ?? 'unknown',
       amount: ethers.formatEther(amount),
     }))
     .sort((a, b) => a.validatorId - b.validatorId);


### PR DESCRIPTION
The script will fetch validator signer address from staking.polygon.technology api to map the address with validator id.